### PR TITLE
Fixed typo in notification

### DIFF
--- a/InventoryWatch/Model.swift
+++ b/InventoryWatch/Model.swift
@@ -515,7 +515,7 @@ final class Model: ObservableObject {
                 }
                 
                 let message = self.generateNotificationText(from: allAvailableModels)
-                NotificationManager.shared.sendNotification(title: hasPreferredModel ? "Preferred Model Found!" : "Apple Store Invetory", body: message)
+                NotificationManager.shared.sendNotification(title: hasPreferredModel ? "Preferred Model Found!" : "Apple Store Inventory", body: message)
             }
         }
     }


### PR DESCRIPTION
Fixed typo: `Invetory` --> `Inventory`