### PR TITLE
fixes #45, patching a parsing bug

### DIFF
--- a/InventoryWatch.xcodeproj/project.pbxproj
+++ b/InventoryWatch.xcodeproj/project.pbxproj
@@ -16,6 +16,11 @@
 		386FDC662739DADD00C1BAC2 /* Model.swift in Sources */ = {isa = PBXBuildFile; fileRef = 386FDC652739DADD00C1BAC2 /* Model.swift */; };
 		386FDC68273A18F800C1BAC2 /* SKUData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 386FDC67273A18F800C1BAC2 /* SKUData.swift */; };
 		386FDC6A273A200000C1BAC2 /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 386FDC69273A200000C1BAC2 /* NotificationManager.swift */; };
+		3885D54C2891711E00BD6A78 /* Store.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3885D54B2891711E00BD6A78 /* Store.swift */; };
+		3885D54E2891713200BD6A78 /* PartAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3885D54D2891713200BD6A78 /* PartAvailability.swift */; };
+		3885D5502891714400BD6A78 /* ProductType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3885D54F2891714400BD6A78 /* ProductType.swift */; };
+		3885D5522891718600BD6A78 /* AllPhoneModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3885D5512891718600BD6A78 /* AllPhoneModels.swift */; };
+		3885D5542891719600BD6A78 /* GithubTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3885D5532891719600BD6A78 /* GithubTag.swift */; };
 		38D0C3A2273C60B500A7DE65 /* Countries.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38D0C3A1273C60B500A7DE65 /* Countries.swift */; };
 		38D307DB2745E2E700A0686D /* Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38D307DA2745E2E700A0686D /* Analytics.swift */; };
 		38DBAF39273D6692009992D8 /* Stores.json in Resources */ = {isa = PBXBuildFile; fileRef = 38DBAF38273D6692009992D8 /* Stores.json */; };
@@ -35,6 +40,11 @@
 		386FDC652739DADD00C1BAC2 /* Model.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Model.swift; sourceTree = "<group>"; };
 		386FDC67273A18F800C1BAC2 /* SKUData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SKUData.swift; sourceTree = "<group>"; };
 		386FDC69273A200000C1BAC2 /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
+		3885D54B2891711E00BD6A78 /* Store.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Store.swift; sourceTree = "<group>"; };
+		3885D54D2891713200BD6A78 /* PartAvailability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PartAvailability.swift; sourceTree = "<group>"; };
+		3885D54F2891714400BD6A78 /* ProductType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductType.swift; sourceTree = "<group>"; };
+		3885D5512891718600BD6A78 /* AllPhoneModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllPhoneModels.swift; sourceTree = "<group>"; };
+		3885D5532891719600BD6A78 /* GithubTag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GithubTag.swift; sourceTree = "<group>"; };
 		38D0C3A1273C60B500A7DE65 /* Countries.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Countries.swift; sourceTree = "<group>"; };
 		38D307DA2745E2E700A0686D /* Analytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Analytics.swift; sourceTree = "<group>"; };
 		38DBAF38273D6692009992D8 /* Stores.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Stores.json; sourceTree = "<group>"; };
@@ -76,7 +86,7 @@
 				386FDC582739DA7300C1BAC2 /* ContentView.swift */,
 				3817268D273AA898003B8D76 /* SettingsView.swift */,
 				386FDC69273A200000C1BAC2 /* NotificationManager.swift */,
-				386FDC652739DADD00C1BAC2 /* Model.swift */,
+				3885D54A289170E700BD6A78 /* Model */,
 				38E1C21927E6714E0047703D /* Helpers.swift */,
 				38D307DA2745E2E700A0686D /* Analytics.swift */,
 				38DBAF38273D6692009992D8 /* Stores.json */,
@@ -97,6 +107,19 @@
 				386FDC5D2739DA7300C1BAC2 /* Preview Assets.xcassets */,
 			);
 			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		3885D54A289170E700BD6A78 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				386FDC652739DADD00C1BAC2 /* Model.swift */,
+				3885D54F2891714400BD6A78 /* ProductType.swift */,
+				3885D54B2891711E00BD6A78 /* Store.swift */,
+				3885D5512891718600BD6A78 /* AllPhoneModels.swift */,
+				3885D54D2891713200BD6A78 /* PartAvailability.swift */,
+				3885D5532891719600BD6A78 /* GithubTag.swift */,
+			);
+			path = Model;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -173,14 +196,19 @@
 			buildActionMask = 2147483647;
 			files = (
 				386FDC662739DADD00C1BAC2 /* Model.swift in Sources */,
+				3885D54E2891713200BD6A78 /* PartAvailability.swift in Sources */,
 				386FDC68273A18F800C1BAC2 /* SKUData.swift in Sources */,
 				38D307DB2745E2E700A0686D /* Analytics.swift in Sources */,
 				386FDC6A273A200000C1BAC2 /* NotificationManager.swift in Sources */,
 				38E1C21A27E6714E0047703D /* Helpers.swift in Sources */,
+				3885D54C2891711E00BD6A78 /* Store.swift in Sources */,
 				3817268E273AA898003B8D76 /* SettingsView.swift in Sources */,
 				386FDC592739DA7300C1BAC2 /* ContentView.swift in Sources */,
+				3885D5542891719600BD6A78 /* GithubTag.swift in Sources */,
 				38D0C3A2273C60B500A7DE65 /* Countries.swift in Sources */,
+				3885D5522891718600BD6A78 /* AllPhoneModels.swift in Sources */,
 				386FDC572739DA7300C1BAC2 /* InventoryWatchApp.swift in Sources */,
+				3885D5502891714400BD6A78 /* ProductType.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -324,7 +352,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.5;
-				MARKETING_VERSION = 0.0.8;
+				MARKETING_VERSION = 0.0.9;
 				PRODUCT_BUNDLE_IDENTIFIER = com.worthbak.InventoryWatch;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -354,7 +382,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.5;
-				MARKETING_VERSION = 0.0.8;
+				MARKETING_VERSION = 0.0.9;
 				PRODUCT_BUNDLE_IDENTIFIER = com.worthbak.InventoryWatch;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/InventoryWatch/Model/AllPhoneModels.swift
+++ b/InventoryWatch/Model/AllPhoneModels.swift
@@ -1,0 +1,30 @@
+//
+//  AllPhoneModels.swift
+//  InventoryWatch
+//
+//  Created by Worth Baker on 7/27/22.
+//
+
+import Foundation
+
+struct AllPhoneModels {
+    struct PhoneModel {
+        let sku: String
+        let productName: String
+    }
+    
+    var proMax13: [PhoneModel]
+    var pro13: [PhoneModel]
+    var mini13: [PhoneModel]
+    var regular13: [PhoneModel]
+    
+    func toSkuData(_ keypath: KeyPath<AllPhoneModels, [AllPhoneModels.PhoneModel]>) -> SKUData {
+        let models = self[keyPath: keypath]
+        
+        let lookup: [String: String] = models.reduce(into: [:]) { acc, next in
+            acc[next.sku] = next.productName
+        }
+        
+        return SKUData(orderedSKUs: models.map { $0.sku }, lookup: lookup)
+    }
+}

--- a/InventoryWatch/Model/GithubTag.swift
+++ b/InventoryWatch/Model/GithubTag.swift
@@ -1,0 +1,12 @@
+//
+//  GithubTag.swift
+//  InventoryWatch
+//
+//  Created by Worth Baker on 7/27/22.
+//
+
+import Foundation
+
+struct GithubTag: Codable {
+    let name: String
+}

--- a/InventoryWatch/Model/PartAvailability.swift
+++ b/InventoryWatch/Model/PartAvailability.swift
@@ -1,0 +1,23 @@
+//
+//  PartAvailability.swift
+//  InventoryWatch
+//
+//  Created by Worth Baker on 7/27/22.
+//
+
+import Foundation
+
+struct PartAvailability: Equatable, Hashable {
+    enum PickupAvailability: String {
+        case available, unavailable, ineligible
+    }
+    
+    let partNumber: String
+    let availability: PickupAvailability
+}
+
+extension PartAvailability: Identifiable {
+    var id: String {
+        partNumber
+    }
+}

--- a/InventoryWatch/Model/ProductType.swift
+++ b/InventoryWatch/Model/ProductType.swift
@@ -1,0 +1,51 @@
+//
+//  ProductType.swift
+//  InventoryWatch
+//
+//  Created by Worth Baker on 7/27/22.
+//
+
+import Foundation
+
+enum ProductType: String, Codable, CaseIterable, Identifiable {
+    var id: Self { self }
+    
+    case MacBookPro
+    case M2MacBookPro13
+    case M2MacBookAir
+    case MacStudio
+    case StudioDisplay
+    case iPadWifi
+    case iPadCellular
+    case iPhoneRegular13
+    case iPhoneMini13
+    case iPhonePro13
+    case iPhoneProMax13
+    
+    var presentableName: String {
+        switch self {
+        case .MacBookPro:
+            return "MacBook Pro"
+        case .M2MacBookPro13:
+            return "M2 MacBook Pro 13in"
+        case .M2MacBookAir:
+            return "M2 MacBook Air"
+        case .MacStudio:
+            return "Mac Studio"
+        case .StudioDisplay:
+            return "Studio Display"
+        case .iPadWifi:
+            return "iPad mini (Wifi)"
+        case .iPadCellular:
+            return "iPad mini (Cellular)"
+        case .iPhoneRegular13:
+            return "iPhone 13"
+        case .iPhoneMini13:
+            return "iPhone 13 mini"
+        case .iPhonePro13:
+            return "iPhone 13 Pro"
+        case .iPhoneProMax13:
+            return "iPhone 13 Pro Max"
+        }
+    }
+}

--- a/InventoryWatch/Model/Store.swift
+++ b/InventoryWatch/Model/Store.swift
@@ -1,0 +1,27 @@
+//
+//  Store.swift
+//  InventoryWatch
+//
+//  Created by Worth Baker on 7/27/22.
+//
+
+import Foundation
+
+struct JsonStore: Codable, Equatable {
+    var storeName: String
+    var storeNumber: String
+    var city: String
+}
+
+struct Store: Equatable {
+    let storeName: String
+    let storeNumber: String
+    let city: String
+    let state: String?
+    
+    var locationDescription: String {
+        return [city, state].compactMap { $0 }.joined(separator: ", ")
+    }
+    
+    let partsAvailability: [PartAvailability]
+}


### PR DESCRIPTION
the fulfillment API moved the `storePickupProductTitle` value to a child object, breaking InventoryWatch parsing. this value wasn't used by the app, though, so the fix was just to remove it as a parsing step. 

also bumps the version to v0.0.9, and does a bit of model code reorganization. 