### PR TITLE
fixes settings window in Ventura (fixes #59)

### DIFF
--- a/InventoryWatch/ContentView.swift
+++ b/InventoryWatch/ContentView.swift
@@ -29,7 +29,13 @@ struct ContentView: View {
                             .offset(x: 8, y: -8)
                     }
                     Button(
-                        action: { NSApp.sendAction(Selector(("showPreferencesWindow:")), to: nil, from: nil) },
+                        action: {
+                            if #available(macOS 13, *) {
+                                NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+                            } else {
+                                NSApp.sendAction(Selector(("showPreferencesWindow:")), to: nil, from: nil)
+                            }
+                        },
                         label: { Image(systemName: "gearshape.fill") }
                     )
                         .buttonStyle(BorderlessButtonStyle())


### PR DESCRIPTION
In macOS Ventura, Apple changed the selector for showing an app's Settings window from `showPreferencesWindow` to `showSettingsWindow` - this PR adds some logic to account for the change. 