### PR TITLE
added some basic HTTP status code error handling

### DIFF
--- a/InventoryWatch.xcodeproj/project.pbxproj
+++ b/InventoryWatch.xcodeproj/project.pbxproj
@@ -363,7 +363,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.5;
-				MARKETING_VERSION = 0.1.5;
+				MARKETING_VERSION = 0.1.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.worthbak.InventoryWatch;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -394,7 +394,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.5;
-				MARKETING_VERSION = 0.1.5;
+				MARKETING_VERSION = 0.1.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.worthbak.InventoryWatch;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/InventoryWatch/Model/Model.swift
+++ b/InventoryWatch/Model/Model.swift
@@ -15,6 +15,7 @@ final class Model: ObservableObject {
     enum ModelError: Swift.Error, LocalizedError {
         case couldNotGenerateURL
         case invalidStoreResponse
+        case storeUnavailable
         case failedToParseJSON
         case unexpectedJSONStructure
         case noStoresFound
@@ -36,6 +37,8 @@ final class Model: ObservableObject {
                 return "InventoryWatch failed to construct a valid URL for your search."
             case .invalidStoreResponse, .failedToParseJSON, .unexpectedJSONStructure, .noStoresFound:
                 return "Unexpected inventory data found. Please confirm that the selected store is valid for the selected country."
+            case .storeUnavailable:
+                return "Apple's fulfillment API returned a server-based error and is currently unavailable."
             case .invalidLocalModelStore:
                 return "InventoryWatch has invalid or currupted local data. Please contact the developer (@worthbak)."
             case .generic(let optional):
@@ -440,7 +443,7 @@ final class Model: ObservableObject {
         
         URLSession.shared.dataTask(with: url) { data, response, error in
             do {
-                try self.parseStoreResponse(data, filterForModels: filterModels)
+                try self.parseStoreResponse(data, response: response as? HTTPURLResponse, filterForModels: filterModels)
             } catch {
                 self.updateErrorState(to: error)
             }
@@ -469,7 +472,16 @@ final class Model: ObservableObject {
         AnalyticsData.updateAnalyticsData()
     }
     
-    private func parseStoreResponse(_ responseData: Data?, filterForModels: Set<String>?) throws {
+    private func parseStoreResponse(_ responseData: Data?, response: HTTPURLResponse?, filterForModels: Set<String>?) throws {
+        if let statusCode = response?.statusCode {
+            switch statusCode {
+            case 500...599:
+                throw ModelError.storeUnavailable
+            default:
+                break
+            }
+        }
+        
         guard let responseData = responseData else {
             throw ModelError.invalidStoreResponse
         }


### PR DESCRIPTION
Apple's fulfillment API is experiencing an extended outage (10/09/22), and InventoryWatch doesn't handle this situation particularly gracefully, showing a message indicating that there could be something wrong with the user's settings. The app should be updated to indicate, in this situation, that the issue appears to lie with Apple's service, not InventoryWatch.

fixes #86, bumps app version number